### PR TITLE
Updated reporter_spec.js to point to correct location under lib

### DIFF
--- a/spec/reporter_spec.js
+++ b/spec/reporter_spec.js
@@ -1,4 +1,4 @@
-var jasmineNode = require(__dirname + "/../lib/jasmine-node/reporter").jasmineNode;
+var jasmineNode = require(__dirname + "/../lib/jasmine-node-karma/reporter").jasmineNode;
 
 describe('TerminalReporter', function() {
   beforeEach(function() {


### PR DESCRIPTION
This was causing issues as it was pointing to jasmine-node instead of jasmine-node-karma.

![module missing error](https://f.cloud.github.com/assets/108946/783638/e87f9692-ea54-11e2-99d5-45febdbafc96.png)
